### PR TITLE
fix: add missing typeof in delay check

### DIFF
--- a/lib/fetch-fares.js
+++ b/lib/fetch-fares.js
@@ -112,7 +112,7 @@ const triasJourneyMatchesOtpItinerary = (logger, it) => (j) => {
 		return false
 	}
 	let itDep = +new Date(itLeg0.startTime)
-	if ('number' === itLeg0.departureDelay) itDep -= itLeg0.departureDelay * 1000 // todo: seconds?
+	if (Number.isInteger(itLeg0.departureDelay)) itDep -= itLeg0.departureDelay * 1000
 	const jDep = +new Date(jLeg0.plannedDeparture)
 	if (itDep !== jDep) {
 		logger.debug(
@@ -133,7 +133,7 @@ const triasJourneyMatchesOtpItinerary = (logger, it) => (j) => {
 		return false
 	}
 	let itArr = +new Date(itLegN.endTime)
-	if ('number' === itLegN.arrivalDelay) itArr -= itLegN.arrivalDelay * 1000 // todo: seconds?
+	if (Number.isInteger(itLegN.arrivalDelay)) itArr -= itLegN.arrivalDelay * 1000
 	const jArr = +new Date(jLegN.plannedArrival)
 	if (itArr !== jArr) {
 		logger.debug(


### PR DESCRIPTION
This PR adds a missing `typeof` in the the delay existance check.

Fixes #14.

